### PR TITLE
Stop-checklist: parse stop_checklist_extra (bugfix) + opt-in git-aware gate and commit-item toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **`stop_checklist_extra` actually works** — 0.8.0 advertised this config key, and `build_stop_prompt` reads it, but `get_project_config` never parsed it from `config.yaml`, so it could never take effect. Added `_parse_string_list` and wired it in.
+
+### Added
+- **`stop_checklist_git_aware`** (bool, default `false`) — when enabled, the stop checklist only blocks if `git status` shows uncommitted changes to code files (by extension; see `CODE_EXTENSIONS`). Docs/config-only turns stop cleanly instead of paying a forced extra turn. Heuristic keys on *uncommitted* state: work already committed to a branch this turn will not re-trigger the checklist. Fails open if git is unavailable. The skip resets the action counter so a later docs-only stop doesn't inherit the accumulated count.
+- **`stop_checklist_commit_item`** (bool, default `true`) — set `false` to suppress the "Commit N uncommitted files" item, for PR-based workflows where the agent must never commit directly. Pair with `stop_checklist_extra` to phrase the project's own delivery step (e.g. "Open a PR").
+
 ## [0.8.0] - 2026-03-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -174,9 +174,26 @@ Current built-in options include:
 pebble_enabled: false
 stop_hook_min_actions: 15
 session_learner_mode: project
+
+# Stop-checklist tuning:
+# Only block the stop when uncommitted CODE files exist (docs/config-only
+# turns stop cleanly). Keys on git status by extension; fails open.
+stop_checklist_git_aware: false
+
+# Suppress the "Commit N uncommitted files" item — for PR-based workflows
+# where the agent must never commit directly. Pair with stop_checklist_extra.
+stop_checklist_commit_item: true
+
+# Custom checklist items appended after the built-ins.
+stop_checklist_extra:
+  - "Open a PR — never commit to main directly"
 ```
 
-Recent versions also support extra stop-checklist items and custom instruction reminders.
+Recent versions also support custom instruction reminders.
+
+Note: `stop_hook_min_actions` counts tool calls **cumulatively** since the
+checklist last fired (not per turn), so it is a cadence dial — raise it to
+make the checklist rarer, not to exempt small turns.
 
 ## Typical workflow
 

--- a/scripts/lib/meridian_config.py
+++ b/scripts/lib/meridian_config.py
@@ -175,10 +175,85 @@ def parse_bool(value: str, default: bool) -> bool:
 # Config key definitions: (yaml_key, config_key, type, default)
 _BOOL_KEYS = [
     ('pebble_enabled', 'pebble_enabled', False),
+    ('stop_checklist_commit_item', 'stop_checklist_commit_item', True),
+    ('stop_checklist_git_aware', 'stop_checklist_git_aware', False),
 ]
 _INT_KEYS = [
     ('stop_hook_min_actions', 'stop_hook_min_actions', 15),
 ]
+
+# File extensions treated as "code" by the git-aware stop-checklist gate.
+CODE_EXTENSIONS = frozenset({
+    '.py', '.js', '.mjs', '.cjs', '.ts', '.tsx', '.jsx', '.vue', '.svelte',
+    '.go', '.rs', '.java', '.kt', '.rb', '.php', '.c', '.h', '.cpp', '.hpp',
+    '.cc', '.cs', '.swift', '.scala', '.sql', '.sh', '.bash', '.zsh',
+})
+
+
+def _parse_string_list(content: str, key: str) -> list[str]:
+    """Parse a simple YAML string list (no PyYAML dependency).
+
+    Expects format:
+        key:
+          - "First item"
+          - Second item
+    """
+    result = []
+    in_section = False
+
+    for line in content.split('\n'):
+        stripped = line.strip()
+
+        if stripped == f'{key}:':
+            in_section = True
+            continue
+
+        if not in_section:
+            continue
+
+        # Exit section on non-indented, non-empty line
+        if stripped and not line[0].isspace():
+            break
+
+        if stripped.startswith('- '):
+            item = stripped[2:].strip().strip('"\'')
+            if item:
+                result.append(item)
+
+    return result
+
+
+def has_uncommitted_code_changes(base_dir: Path) -> bool:
+    """True if git shows uncommitted changes (staged, unstaged, or untracked)
+    to files with a code extension. Used by the git-aware stop-checklist gate
+    so docs/config-only turns don't pay a blocked stop.
+
+    Fails open (returns True) if git is unavailable or errors — the checklist
+    should degrade to its pre-gate behavior, not silently disable itself.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=str(base_dir)
+        )
+        if result.returncode != 0:
+            return True
+        for line in result.stdout.splitlines():
+            if len(line) < 4:
+                continue
+            path = line[3:].strip()
+            # Renames report "old -> new"; the new path is what matters
+            if ' -> ' in path:
+                path = path.split(' -> ', 1)[1]
+            path = path.strip('"')
+            if Path(path).suffix.lower() in CODE_EXTENSIONS:
+                return True
+        return False
+    except Exception:
+        return True
 
 
 def _parse_extra_doc_dirs(content: str) -> list[dict]:
@@ -236,6 +311,9 @@ def get_project_config(base_dir: Path) -> dict:
         'stop_hook_min_actions': 15,
         'session_learner_mode': 'project',
         'extra_doc_dirs': [],
+        'stop_checklist_extra': [],
+        'stop_checklist_commit_item': True,
+        'stop_checklist_git_aware': False,
     }
 
     config_path = base_dir / MERIDIAN_CONFIG
@@ -263,6 +341,7 @@ def get_project_config(base_dir: Path) -> dict:
             config['session_learner_mode'] = sl_mode.lower()
 
         config['extra_doc_dirs'] = _parse_extra_doc_dirs(content)
+        config['stop_checklist_extra'] = _parse_string_list(content, 'stop_checklist_extra')
 
     except IOError:
         pass
@@ -986,20 +1065,23 @@ def build_stop_prompt(base_dir: Path, config: dict) -> str:
             if isinstance(item, str) and item.strip():
                 parts.append(f"- {item.strip()}")
 
-    # Check for uncommitted changes
-    try:
-        result = subprocess.run(
-            ["git", "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-            cwd=str(base_dir)
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            changed_files = len([l for l in result.stdout.strip().split('\n') if l])
-            parts.append(f"- Commit {changed_files} uncommitted file{'s' if changed_files != 1 else ''}")
-    except Exception:
-        pass
+    # Check for uncommitted changes (suppressible for PR-based workflows
+    # where the agent must never commit directly — use stop_checklist_extra
+    # to phrase the project's own delivery step instead)
+    if config.get('stop_checklist_commit_item', True):
+        try:
+            result = subprocess.run(
+                ["git", "status", "--porcelain"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=str(base_dir)
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                changed_files = len([l for l in result.stdout.strip().split('\n') if l])
+                parts.append(f"- Commit {changed_files} uncommitted file{'s' if changed_files != 1 else ''}")
+        except Exception:
+            pass
 
     parts.append("")
     parts.append("Skip items you already completed. Do the rest now.")

--- a/scripts/stop-checklist.py
+++ b/scripts/stop-checklist.py
@@ -21,6 +21,7 @@ from meridian_config import (
     log_hook_output,
     get_action_counter,
     reset_action_counter,
+    has_uncommitted_code_changes,
 )
 
 
@@ -58,6 +59,15 @@ def main():
         action_count = get_action_counter(base_dir)
         if action_count < min_actions:
             sys.exit(0)  # Allow stop — counter keeps accumulating
+
+    # Git-aware gate: when enabled, only block if uncommitted CODE changes
+    # exist. Docs/config-only work doesn't warrant the reviewer/tests
+    # checklist. Reset the counter so a later docs-only stop doesn't
+    # inherit this window's accumulated count.
+    if config.get('stop_checklist_git_aware', False):
+        if not has_uncommitted_code_changes(base_dir):
+            reset_action_counter(base_dir)
+            sys.exit(0)
 
     # Build the stop prompt using shared helper
     reason = build_stop_prompt(base_dir, config)


### PR DESCRIPTION
## Bugfix: `stop_checklist_extra` never worked

The 0.8.0 changelog advertises `stop_checklist_extra`, and `build_stop_prompt` reads it (`config.get('stop_checklist_extra', [])`), but `get_project_config` only parses `_BOOL_KEYS`, `_INT_KEYS`, `session_learner_mode`, and `extra_doc_dirs` — so the key can never reach the prompt builder from `config.yaml`. Any user who set it hit silent failure.

Fix: a `_parse_string_list` helper in the same no-PyYAML style as `_parse_extra_doc_dirs`, wired into `get_project_config`.

## Two opt-in additions (defaults preserve current behavior exactly)

Context: over a month of daily use on one project, the stop checklist blocked 1,000+ stops, each forcing an extra model turn — including turns where only docs or config changed, and in a workflow where the "Commit N uncommitted files" item contradicts a never-commit-directly / PR-only delivery rule.

- **`stop_checklist_git_aware`** (default `false`) — when enabled, the checklist only blocks if `git status --porcelain` shows uncommitted changes to code files (by extension, `CODE_EXTENSIONS`). Docs/config-only turns stop cleanly. Fails open if git is unavailable or errors; the skip resets the action counter so a later docs-only stop doesn't inherit the accumulated count. Known limitation (documented in CHANGELOG): it keys on *uncommitted* state, so work already committed to a branch that turn won't re-trigger the checklist.
- **`stop_checklist_commit_item`** (default `true`) — set `false` to suppress the commit item for PR-based workflows, pairing with `stop_checklist_extra` to phrase the project's own delivery step (e.g. "Open a PR — never commit to main directly").

Also added a README note that `stop_hook_min_actions` counts **cumulatively** since the checklist last fired (per the 0.8.0 action-counter change), so it behaves as a cadence dial rather than a per-turn triviality gate — this surprised us in practice.

## Testing

15-case functional test run against these changes: config parsing (quoted/unquoted items, absent-key defaults), prompt assembly (extra items included, commit item suppressible, default unchanged), and the git-aware gate (docs-only dirty → skip, untracked code file → block, clean tree → skip, staged rename of code file → block, non-git dir → fails open). All pass; `py_compile` clean on both touched scripts.

Happy to split the bugfix from the two features if you'd prefer smaller PRs.