### PR TITLE
Fix session learner being cancelled on SessionEnd

### DIFF
--- a/scripts/session-learner.py
+++ b/scripts/session-learner.py
@@ -10,6 +10,10 @@ Extracts session transcript and spawns a headless Claude session to:
 Fires on SessionEnd (session over) and PreCompact (checkpoint before context compaction).
 The lock prevents concurrent runs — if PreCompact is still running when SessionEnd fires, the
 SessionEnd run will skip (lock held). This is acceptable since PreCompact already captured the work.
+
+On SessionEnd the hook re-spawns itself detached and returns immediately: Claude Code cancels
+SessionEnd hooks when the CLI process exits ("Hook cancelled"), long before the headless
+`claude -p` run finishes, so the real work must outlive its parent.
 """
 
 import json
@@ -30,6 +34,8 @@ if is_headless():
 WORKSPACE_SYNC_LOCK = "workspace-sync.lock"
 SESSION_LEARNER_LOG = "session-learner.jsonl"
 SESSION_LEARNER_DEBUG_LOG = "session-learner.log"
+SESSION_LEARNER_PAYLOAD = "session-learner-payload.json"
+DETACH_ENV_FLAG = "MERIDIAN_LEARNER_DETACHED"
 MAX_LOG_ENTRIES = 50
 MIN_ENTRIES_THRESHOLD = 5  # Skip if fewer than this many meaningful entries
 
@@ -544,6 +550,27 @@ def log(project_dir: Path, message: str):
         pass
 
 
+def spawn_detached(input_data: dict, project_dir: Path) -> None:
+    """Re-run this script in a new session so it survives the parent CLI exiting."""
+    payload_path = state_path(project_dir, SESSION_LEARNER_PAYLOAD)
+    payload_path.parent.mkdir(parents=True, exist_ok=True)
+    payload_path.write_text(json.dumps(input_data))
+
+    env = dict(os.environ)
+    env[DETACH_ENV_FLAG] = "1"
+
+    with open(payload_path) as stdin_f, open(os.devnull, "w") as devnull:
+        subprocess.Popen(
+            [sys.executable, str(Path(__file__).resolve())],
+            stdin=stdin_f,
+            stdout=devnull,
+            stderr=devnull,
+            env=env,
+            cwd=str(project_dir if project_dir.exists() else Path.cwd()),
+            start_new_session=True,
+        )
+
+
 def main():
     try:
         input_data = json.load(sys.stdin)
@@ -562,6 +589,17 @@ def main():
         log(project_dir, f"SKIP wrong event: {hook_event}")
         log_skip(project_dir, "wrong_event", hook_event=hook_event)
         sys.exit(0)
+
+    # SessionEnd hooks are killed when the CLI exits — hand the work to a detached
+    # copy of ourselves and return immediately so nothing gets cancelled mid-run.
+    if hook_event == "SessionEnd" and os.environ.get(DETACH_ENV_FLAG) != "1":
+        try:
+            spawn_detached(input_data, project_dir)
+        except Exception as e:
+            log(project_dir, f"detach failed ({type(e).__name__}: {e}) — running inline")
+        else:
+            log(project_dir, "detached run spawned — parent exiting")
+            sys.exit(0)
 
     lock_acquired = False
     try:


### PR DESCRIPTION
## Problem

Every `claude` exit prints:

```
SessionEnd hook [python3 "${CLAUDE_PLUGIN_ROOT}/scripts/session-learner.py"] failed: Hook cancelled
SessionEnd hook [python3 "${CLAUDE_PLUGIN_ROOT}/scripts/session-transcript.py"] failed: Hook cancelled
```

`session-learner.py` spawns a headless `claude -p` run that takes 20–130s, but Claude Code kills `SessionEnd` hooks as soon as the CLI process exits — well before the `timeout: 180` in `hooks.json` could ever matter. So the learner is cancelled mid-flight, and `session-transcript.py`, queued behind it in the same hook group, is cancelled too.

Net effect: workspace/doc/correction learning only ever lands through the **async PreCompact** path. The SessionEnd path has never completed.

From my own `~/.meridian/state/<hash>/session-learner.log` — every SessionEnd entry stops dead after `lock acquired`, while PreCompact entries reach `DONE`:

```
[08:09:08] START event=SessionEnd transcript=6e170387-....jsonl
[08:09:08] lock acquired
[09:46:44] START event=SessionEnd transcript=2f1722e0-....jsonl     <- next session, nothing in between
[09:46:44] lock acquired
[09:46:44] extracted entries=157 meaningful=32
```

One run got far enough to show the money being spent and then thrown away:

```
[13:05:37] calling claude -p...
[13:07:38] claude exited with code 1
[13:07:38] claude -p done exit_code=1 duration=120s tools=6    ("total_cost_usd": 1.83)
[13:07:38] FAILED exit_code=1
```

A cancelled run also strands `workspace-sync.lock`, which then suppresses the next run until the 5-minute staleness window passes.

## Fix

On `SessionEnd`, `session-learner.py` re-spawns itself with `start_new_session=True`, hands the hook payload over via `session-learner-payload.json` in the state dir, and returns in ~0.15s. The detached copy acquires the lock and does the real work, outliving the parent's teardown.

- `PreCompact` behaviour is unchanged (still inline, still `async: true` per `hooks.json`).
- Re-entry is guarded by `MERIDIAN_LEARNER_DETACHED=1`, so the child runs the normal path exactly once.
- If the spawn raises, it logs and falls back to the previous inline behaviour — no new failure mode.
- No change needed in `hooks.json`.

## Verification

- `python3 -m py_compile scripts/session-learner.py` clean on this branch (i.e. against upstream `main`).
- Synthetic SessionEnd payload against a throwaway `CLAUDE_PROJECT_DIR`: parent exited `0` in **0.15s**, and the detached child wrote its own lifecycle lines to the state dir:
  ```
  [09:50:56] START event=SessionEnd transcript=fake-transcript.jsonl
  [09:50:56] detached run spawned — parent exiting
  [09:50:56] START event=SessionEnd transcript=fake-transcript.jsonl
  [09:50:56] lock acquired
  [09:50:56] extracted entries=2 meaningful=2
  [09:50:56] SKIP below threshold (2 < 5)
  [09:50:56] lock released
  ```
- OS-level survival: a child spawned this way outlived a `SIGKILL` sent to the parent's entire process group.
- Running live on macOS (Darwin 21.6.0) from my fork.

## Notes

- I left the version bump and CHANGELOG entry to you, so this is a single-file diff.
- `scripts/session-learner.py` is byte-identical between upstream `main` and my fork's pre-fix base, so nothing fork-specific is riding along here.
